### PR TITLE
Add IPv6 support

### DIFF
--- a/client.go
+++ b/client.go
@@ -46,19 +46,23 @@ func NewClient(key, hmacKey string) (c *Client, err error) {
 		key:     decodedKey,
 		hmacKey: decodedHmacKey,
 	}
-	c.resolvePublicIPs()
+	if err = c.resolvePublicIPs(); err != nil {
+		return
+	}
 	return
 }
 
 // Auth is the main function for the client
 func (c *Client) Auth(host string, port int) (err error) {
-	c.resolvePublicIPs()
+	if err = c.resolvePublicIPs(); err != nil {
+		return
+	}
 	return c.send(host, port)
 }
 
-func (c *Client) resolvePublicIPs() {
+func (c *Client) resolvePublicIPs() error {
 	if len(c.IPs) > 0 {
-		return
+		return nil
 	}
 	var v4 net.IP
 	var v6 net.IP
@@ -79,6 +83,10 @@ func (c *Client) resolvePublicIPs() {
 	if v6 != nil {
 		c.IPs = append(c.IPs, v6)
 	}
+	if len(c.IPs) == 0 {
+		return fmt.Errorf("failed to resolve any public IP addresses")
+	}
+	return nil
 }
 
 func fetchPublicIP(url string) net.IP {
@@ -148,22 +156,24 @@ func (c *Client) send(host string, port int) error {
 	if err != nil {
 		return err
 	}
+	var errs []error
 	for _, addr := range addrs {
 		serverAddr, err := net.ResolveUDPAddr("udp", net.JoinHostPort(addr, fmt.Sprintf("%d", port)))
 		if err != nil {
-			return err
+			errs = append(errs, err)
+			continue
 		}
 		conn, err := net.DialUDP("udp", nil, serverAddr)
 		if err != nil {
-			return err
+			errs = append(errs, err)
+			continue
 		}
 		if err := c.sendAllPackets(conn); err != nil {
-			conn.Close()
-			return err
+			errs = append(errs, err)
 		}
 		conn.Close()
 	}
-	return nil
+	return errors.Join(errs...)
 }
 
 func (c *Client) sendAllPackets(conn *net.UDPConn) error {

--- a/client.go
+++ b/client.go
@@ -2,18 +2,19 @@ package sparoid
 
 import (
 	"bytes"
-	"context"
 	"crypto/aes"
 	"crypto/cipher"
 	"crypto/hmac"
 	"crypto/rand"
 	"crypto/sha256"
-	"encoding/binary"
 	"encoding/hex"
 	"errors"
 	"fmt"
 	"io"
 	"net"
+	"net/http"
+	"strings"
+	"sync"
 	"time"
 )
 
@@ -23,7 +24,7 @@ const VERSION = "0.0.1"
 // Client is the main struct for the client
 type Client struct {
 	key, hmacKey []byte
-	IP           net.IP
+	IPs          []net.IPNet
 }
 
 // ErrKeyLength is returned when the key is not 32 bytes
@@ -45,61 +46,83 @@ func NewClient(key, hmacKey string) (c *Client, err error) {
 		key:     decodedKey,
 		hmacKey: decodedHmacKey,
 	}
-	c.IP, err = c.publicIP()
-	if err != nil {
-		return
-	}
+	c.resolvePublicIPs()
 	return
 }
 
 // Auth is the main function for the client
 func (c *Client) Auth(host string, port int) (err error) {
-	c.IP, err = c.publicIP()
-	if err != nil {
-		return
-	}
+	c.resolvePublicIPs()
 	return c.send(host, port)
 }
 
-func (c *Client) publicIP() (net.IP, error) {
-	if c.IP != nil {
-		return c.IP, nil
+func (c *Client) resolvePublicIPs() {
+	if len(c.IPs) > 0 {
+		return
 	}
-	resolver := net.Resolver{
-		PreferGo: true,
-		Dial: func(ctx context.Context, network, address string) (net.Conn, error) {
-			d := net.Dialer{}
-			return d.DialContext(ctx, "udp", "208.67.222.222:53")
-		},
+	var v4 net.IP
+	var v6nets []net.IPNet
+	var wg sync.WaitGroup
+	wg.Go(func() {
+		v4 = fetchPublicIP("https://ipv4.icanhazip.com")
+	})
+	wg.Go(func() {
+		v6nets = globalIPv6FromInterfaces()
+		if len(v6nets) == 0 {
+			if ip := fetchPublicIP("https://ipv6.icanhazip.com"); ip != nil {
+				v6nets = []net.IPNet{{IP: ip, Mask: net.CIDRMask(128, 128)}}
+			}
+		}
+	})
+	wg.Wait()
+	if v4 != nil {
+		c.IPs = append(c.IPs, net.IPNet{IP: v4.To4(), Mask: net.CIDRMask(32, 32)})
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
-	ip, err := resolver.LookupHost(ctx, "myip.opendns.com")
-	if err != nil {
-		return nil, err
-	}
-
-	return net.ParseIP(ip[0]), nil
+	c.IPs = append(c.IPs, v6nets...)
 }
 
-func (c *Client) message() []byte {
-	version := uint32(1)
-	ts := uint64(time.Now().UTC().UnixNano() / int64(time.Millisecond))
-	nounce := make([]byte, 16)
-	rand.Read(nounce)
-	ipBytes := c.IP.To4()
+func fetchPublicIP(url string) net.IP {
+	client := &http.Client{Timeout: 5 * time.Second}
+	resp, err := client.Get(url)
+	if err != nil {
+		return nil
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil
+	}
+	return net.ParseIP(strings.TrimSpace(string(body)))
+}
 
-	buf := make([]byte, 4+8+16+4)
-	binary.BigEndian.PutUint32(buf[0:4], version)
-	binary.BigEndian.PutUint64(buf[4:12], ts)
-	copy(buf[12:28], nounce)
-	copy(buf[28:32], ipBytes)
-
-	return buf
+func globalIPv6FromInterfaces() []net.IPNet {
+	var result []net.IPNet
+	ifaces, err := net.Interfaces()
+	if err != nil {
+		return nil
+	}
+	for _, iface := range ifaces {
+		addrs, err := iface.Addrs()
+		if err != nil {
+			continue
+		}
+		for _, addr := range addrs {
+			ipNet, ok := addr.(*net.IPNet)
+			if !ok {
+				continue
+			}
+			if ipNet.IP.To4() != nil {
+				continue
+			}
+			if ipNet.IP.IsGlobalUnicast() && !ipNet.IP.IsPrivate() {
+				result = append(result, *ipNet)
+			}
+		}
+	}
+	return result
 }
 
 func (c *Client) encrypt(message []byte) (out []byte, err error) {
-	// convert key hexstring to bytes
 	block, err := aes.NewCipher(c.key)
 	if err != nil {
 		return
@@ -107,7 +130,6 @@ func (c *Client) encrypt(message []byte) (out []byte, err error) {
 
 	message = pad(message)
 	out = make([]byte, aes.BlockSize+len(message))
-	//iv is the ciphertext up to the blocksize (16)
 	iv := out[:aes.BlockSize]
 	if _, err = io.ReadFull(rand.Reader, iv); err != nil {
 		return
@@ -134,20 +156,47 @@ func (c *Client) prefixHMAC(message []byte) (out []byte) {
 }
 
 func (c *Client) send(host string, port int) error {
-	serverAddr, err := net.ResolveUDPAddr("udp", fmt.Sprintf("%s:%d", host, port))
+	addrs, err := net.LookupHost(host)
 	if err != nil {
 		return err
 	}
-	conn, err := net.DialUDP("udp", nil, serverAddr)
-	if err != nil {
-		return err
+	for _, addr := range addrs {
+		serverAddr, err := net.ResolveUDPAddr("udp", net.JoinHostPort(addr, fmt.Sprintf("%d", port)))
+		if err != nil {
+			return err
+		}
+		conn, err := net.DialUDP("udp", nil, serverAddr)
+		if err != nil {
+			return err
+		}
+		if err := c.sendAllPackets(conn); err != nil {
+			conn.Close()
+			return err
+		}
+		conn.Close()
 	}
-	defer conn.Close()
-	encrypted, err := c.encrypt(c.message())
+	return nil
+}
+
+func (c *Client) sendAllPackets(conn *net.UDPConn) error {
+	var errs []error
+	for _, ipNet := range c.IPs {
+		ones, _ := ipNet.Mask.Size()
+		if msg, err := MessageV2(ipNet.IP, uint8(ones)); err != nil {
+			errs = append(errs, err)
+		} else {
+			errs = append(errs, c.sendPacket(conn, msg))
+		}
+	}
+	return errors.Join(errs...)
+}
+
+func (c *Client) sendPacket(conn *net.UDPConn, msg []byte) error {
+	encrypted, err := c.encrypt(msg)
 	if err != nil {
 		return err
 	}
 	prefixed := c.prefixHMAC(encrypted)
-	conn.Write(prefixed)
+	_, err = conn.Write(prefixed)
 	return err
 }

--- a/client.go
+++ b/client.go
@@ -24,7 +24,7 @@ const VERSION = "0.0.1"
 // Client is the main struct for the client
 type Client struct {
 	key, hmacKey []byte
-	IPs          []net.IPNet
+	IPs          []net.IP
 }
 
 // ErrKeyLength is returned when the key is not 32 bytes
@@ -61,24 +61,24 @@ func (c *Client) resolvePublicIPs() {
 		return
 	}
 	var v4 net.IP
-	var v6nets []net.IPNet
+	var v6 net.IP
 	var wg sync.WaitGroup
 	wg.Go(func() {
 		v4 = fetchPublicIP("https://ipv4.icanhazip.com")
 	})
 	wg.Go(func() {
-		v6nets = globalIPv6FromInterfaces()
-		if len(v6nets) == 0 {
-			if ip := fetchPublicIP("https://ipv6.icanhazip.com"); ip != nil {
-				v6nets = []net.IPNet{{IP: ip, Mask: net.CIDRMask(128, 128)}}
-			}
+		v6 = publicIPv6()
+		if v6 == nil {
+			v6 = fetchPublicIP("https://ipv6.icanhazip.com")
 		}
 	})
 	wg.Wait()
 	if v4 != nil {
-		c.IPs = append(c.IPs, net.IPNet{IP: v4.To4(), Mask: net.CIDRMask(32, 32)})
+		c.IPs = append(c.IPs, v4.To4())
 	}
-	c.IPs = append(c.IPs, v6nets...)
+	if v6 != nil {
+		c.IPs = append(c.IPs, v6)
+	}
 }
 
 func fetchPublicIP(url string) net.IP {
@@ -95,31 +95,19 @@ func fetchPublicIP(url string) net.IP {
 	return net.ParseIP(strings.TrimSpace(string(body)))
 }
 
-func globalIPv6FromInterfaces() []net.IPNet {
-	var result []net.IPNet
-	ifaces, err := net.Interfaces()
+// publicIPv6 gets the public IPv6 address by asking the OS which source address
+// it would use to reach a well-known IPv6 destination (Google DNS).
+func publicIPv6() net.IP {
+	conn, err := net.DialTimeout("udp6", "[2001:4860:4860::8888]:53", 2*time.Second)
 	if err != nil {
 		return nil
 	}
-	for _, iface := range ifaces {
-		addrs, err := iface.Addrs()
-		if err != nil {
-			continue
-		}
-		for _, addr := range addrs {
-			ipNet, ok := addr.(*net.IPNet)
-			if !ok {
-				continue
-			}
-			if ipNet.IP.To4() != nil {
-				continue
-			}
-			if ipNet.IP.IsGlobalUnicast() && !ipNet.IP.IsPrivate() {
-				result = append(result, *ipNet)
-			}
-		}
+	defer conn.Close()
+	addr := conn.LocalAddr().(*net.UDPAddr)
+	if addr.IP.IsGlobalUnicast() && !addr.IP.IsPrivate() {
+		return addr.IP
 	}
-	return result
+	return nil
 }
 
 func (c *Client) encrypt(message []byte) (out []byte, err error) {
@@ -180,9 +168,8 @@ func (c *Client) send(host string, port int) error {
 
 func (c *Client) sendAllPackets(conn *net.UDPConn) error {
 	var errs []error
-	for _, ipNet := range c.IPs {
-		ones, _ := ipNet.Mask.Size()
-		if msg, err := MessageV2(ipNet.IP, uint8(ones)); err != nil {
+	for _, ip := range c.IPs {
+		if msg, err := Message(ip); err != nil {
 			errs = append(errs, err)
 		} else {
 			errs = append(errs, c.sendPacket(conn, msg))

--- a/client_test.go
+++ b/client_test.go
@@ -12,12 +12,6 @@ var (
 	client, _ = NewClient(key, hmacKey)
 )
 
-func ipNet(cidr string) net.IPNet {
-	ip, n, _ := net.ParseCIDR(cidr)
-	n.IP = ip // preserve the host IP, not the masked network address
-	return *n
-}
-
 func TestClientCreatesNewClient(t *testing.T) {
 	client, err := NewClient(key, hmacKey)
 	if err != nil {
@@ -37,8 +31,8 @@ func TestClientGuardsAgainstShortKeys(t *testing.T) {
 }
 
 func TestClientEncryptsMessages(t *testing.T) {
-	c := &Client{key: client.key, hmacKey: client.hmacKey, IPs: []net.IPNet{ipNet("127.0.0.1/32")}}
-	msg, err := MessageV2(net.ParseIP("127.0.0.1"), 32)
+	c := &Client{key: client.key, hmacKey: client.hmacKey, IPs: []net.IP{net.ParseIP("127.0.0.1").To4()}}
+	msg, err := Message(net.ParseIP("127.0.0.1").To4())
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
@@ -46,15 +40,15 @@ func TestClientEncryptsMessages(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
-	// 34 bytes padded to 48 + 16 IV = 64
+	// 32 bytes + 16 PKCS7 padding = 48 + 16 IV = 64
 	if len(encrypted) != 64 {
 		t.Errorf("Expected encrypted message length to be 64, got %d", len(encrypted))
 	}
 }
 
 func TestClientAddsHMAC(t *testing.T) {
-	c := &Client{key: client.key, hmacKey: client.hmacKey, IPs: []net.IPNet{ipNet("127.0.0.1/32")}}
-	msg, _ := MessageV2(net.ParseIP("127.0.0.1"), 32)
+	c := &Client{key: client.key, hmacKey: client.hmacKey, IPs: []net.IP{net.ParseIP("127.0.0.1").To4()}}
+	msg, _ := Message(net.ParseIP("127.0.0.1").To4())
 	encrypted, _ := c.encrypt(msg)
 	prefixed := c.prefixHMAC(encrypted)
 	// 64 encrypted + 32 HMAC = 96
@@ -68,7 +62,7 @@ func TestClientSendsIPv4Packet(t *testing.T) {
 	defer server.Close()
 	port := server.LocalAddr().(*net.UDPAddr).Port
 
-	c := &Client{key: client.key, hmacKey: client.hmacKey, IPs: []net.IPNet{ipNet("127.0.0.1/32")}}
+	c := &Client{key: client.key, hmacKey: client.hmacKey, IPs: []net.IP{net.ParseIP("127.0.0.1").To4()}}
 	go func() {
 		err := c.Auth("127.0.0.1", port)
 		if err != nil {
@@ -77,7 +71,7 @@ func TestClientSendsIPv4Packet(t *testing.T) {
 	}()
 
 	buf := make([]byte, 512)
-	// v2 IPv4 (34 bytes -> pad to 48 -> +16 IV = 64 encrypted -> +32 HMAC = 96)
+	// v1 IPv4 (32 bytes + 16 pad = 48 -> +16 IV = 64 encrypted -> +32 HMAC = 96)
 	n, _, err := server.ReadFrom(buf)
 	if err != nil {
 		t.Fatalf("Expected no error %s", err)
@@ -92,7 +86,7 @@ func TestClientSendsIPv6Packet(t *testing.T) {
 	defer server.Close()
 	port := server.LocalAddr().(*net.UDPAddr).Port
 
-	c := &Client{key: client.key, hmacKey: client.hmacKey, IPs: []net.IPNet{ipNet("2001:db8::1/64")}}
+	c := &Client{key: client.key, hmacKey: client.hmacKey, IPs: []net.IP{net.ParseIP("2001:db8::1")}}
 	go func() {
 		err := c.send("127.0.0.1", port)
 		if err != nil {
@@ -101,14 +95,13 @@ func TestClientSendsIPv6Packet(t *testing.T) {
 	}()
 
 	buf := make([]byte, 512)
-
-	// v2 IPv6 (46 bytes -> pad to 48 -> +16 IV = 64 encrypted -> +32 HMAC = 96)
+	// v1 IPv6 (44 bytes -> pad to 48 -> +16 IV = 64 encrypted -> +32 HMAC = 96)
 	n, _, err := server.ReadFrom(buf)
 	if err != nil {
 		t.Fatalf("Expected no error %s", err)
 	}
 	if n != 96 {
-		t.Errorf("Expected v2 IPv6 packet length to be 96, got %d", n)
+		t.Errorf("Expected v1 IPv6 packet length to be 96, got %d", n)
 	}
 }
 
@@ -119,7 +112,7 @@ func TestClientSendsBothIPv4AndIPv6(t *testing.T) {
 
 	c := &Client{
 		key: client.key, hmacKey: client.hmacKey,
-		IPs: []net.IPNet{ipNet("127.0.0.1/32"), ipNet("2001:db8::1/64")},
+		IPs: []net.IP{net.ParseIP("127.0.0.1").To4(), net.ParseIP("2001:db8::1")},
 	}
 	go func() {
 		err := c.send("127.0.0.1", port)
@@ -129,14 +122,14 @@ func TestClientSendsBothIPv4AndIPv6(t *testing.T) {
 	}()
 
 	buf := make([]byte, 512)
-	// Expect 2 packets: v2 IPv4 + v2 IPv6 (IPv4 first)
+	// Expect 2 packets: IPv4 (80 bytes) + IPv6 (96 bytes)
 	for i := 0; i < 2; i++ {
 		n, _, err := server.ReadFrom(buf)
 		if err != nil {
 			t.Fatalf("packet %d: unexpected error: %s", i, err)
 		}
-		if n != 96 {
-			t.Errorf("packet %d: expected length 96, got %d", i, n)
+		if n != 80 && n != 96 {
+			t.Errorf("packet %d: expected length 80 or 96, got %d", i, n)
 		}
 	}
 }

--- a/client_test.go
+++ b/client_test.go
@@ -1,13 +1,9 @@
 package sparoid
 
 import (
-	//"bytes"
+	"errors"
 	"net"
 	"testing"
-
-	//"golang.org/x/crypto/ssh"
-	"errors"
-	"regexp"
 )
 
 var (
@@ -15,6 +11,12 @@ var (
 	hmacKey   = "0000000000000000000000000000000000000000000000000000000000000000"
 	client, _ = NewClient(key, hmacKey)
 )
+
+func ipNet(cidr string) net.IPNet {
+	ip, n, _ := net.ParseCIDR(cidr)
+	n.IP = ip // preserve the host IP, not the masked network address
+	return *n
+}
 
 func TestClientCreatesNewClient(t *testing.T) {
 	client, err := NewClient(key, hmacKey)
@@ -34,84 +36,108 @@ func TestClientGuardsAgainstShortKeys(t *testing.T) {
 	}
 }
 
-func TestClientResolvesPublicIP(t *testing.T) {
-	ip, err := client.publicIP()
-	if err != nil {
-		t.Errorf("Expected no error %s", err)
-	}
-	match, err := regexp.MatchString(`^\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}$`, ip.String())
-	if err != nil {
-		t.Errorf("Expected no error %s", err)
-	}
-	if !match {
-		t.Errorf("Expected IP address to match pattern")
-	}
-}
-
-func TestClientCreatesAMessage(t *testing.T) {
-	message := client.message()
-	if len(message) != 32 {
-		t.Errorf("Expected message length to be 32, got %d", len(message))
-	}
-}
-
 func TestClientEncryptsMessages(t *testing.T) {
-	message := client.message()
-	encrypted, err := client.encrypt(message)
+	c := &Client{key: client.key, hmacKey: client.hmacKey, IPs: []net.IPNet{ipNet("127.0.0.1/32")}}
+	msg, err := MessageV2(net.ParseIP("127.0.0.1"), 32)
 	if err != nil {
-		t.Errorf("Expected no error %s", err)
-		t.FailNow()
+		t.Fatalf("unexpected error: %s", err)
 	}
-	t.Logf("Encrypted message: %x", encrypted)
+	encrypted, err := c.encrypt(msg)
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	// 34 bytes padded to 48 + 16 IV = 64
 	if len(encrypted) != 64 {
 		t.Errorf("Expected encrypted message length to be 64, got %d", len(encrypted))
 	}
 }
 
 func TestClientAddsHMAC(t *testing.T) {
-	message := client.message()
-	encrypted, _ := client.encrypt(message)
-	prefixed := client.prefixHMAC(encrypted)
+	c := &Client{key: client.key, hmacKey: client.hmacKey, IPs: []net.IPNet{ipNet("127.0.0.1/32")}}
+	msg, _ := MessageV2(net.ParseIP("127.0.0.1"), 32)
+	encrypted, _ := c.encrypt(msg)
+	prefixed := c.prefixHMAC(encrypted)
+	// 64 encrypted + 32 HMAC = 96
 	if len(prefixed) != 96 {
 		t.Errorf("Expected prefixed message length to be 96, got %d", len(prefixed))
 	}
 }
 
-func TestClientSendsMessage(t *testing.T) {
+func TestClientSendsIPv4Packet(t *testing.T) {
 	server, _ := net.ListenPacket("udp", "127.0.0.1:0")
 	defer server.Close()
 	port := server.LocalAddr().(*net.UDPAddr).Port
+
+	c := &Client{key: client.key, hmacKey: client.hmacKey, IPs: []net.IPNet{ipNet("127.0.0.1/32")}}
 	go func() {
-		err := client.Auth("127.0.0.1", port)
+		err := c.Auth("127.0.0.1", port)
 		if err != nil {
 			t.Errorf("Expected no error %s", err)
 		}
 	}()
+
 	buf := make([]byte, 512)
+	// v2 IPv4 (34 bytes -> pad to 48 -> +16 IV = 64 encrypted -> +32 HMAC = 96)
 	n, _, err := server.ReadFrom(buf)
 	if err != nil {
-		t.Errorf("Expected no error %s", err)
+		t.Fatalf("Expected no error %s", err)
 	}
 	if n != 96 {
-		t.Errorf("Expected received message length to be 96 got %d", n)
+		t.Errorf("Expected packet length to be 96, got %d", n)
 	}
 }
 
-func TestClientOpensPortForPassedInIPArgument(t *testing.T) {
-	ip := "127.0.0.1"
+func TestClientSendsIPv6Packet(t *testing.T) {
 	server, _ := net.ListenPacket("udp", "127.0.0.1:0")
 	defer server.Close()
 	port := server.LocalAddr().(*net.UDPAddr).Port
+
+	c := &Client{key: client.key, hmacKey: client.hmacKey, IPs: []net.IPNet{ipNet("2001:db8::1/64")}}
 	go func() {
-		err := client.Auth(ip, port)
+		err := c.send("127.0.0.1", port)
 		if err != nil {
 			t.Errorf("Expected no error %s", err)
 		}
 	}()
+
 	buf := make([]byte, 512)
-	n, _, _ := server.ReadFrom(buf)
+
+	// v2 IPv6 (46 bytes -> pad to 48 -> +16 IV = 64 encrypted -> +32 HMAC = 96)
+	n, _, err := server.ReadFrom(buf)
+	if err != nil {
+		t.Fatalf("Expected no error %s", err)
+	}
 	if n != 96 {
-		t.Errorf("Expected received message length to be 96, got %d", n)
+		t.Errorf("Expected v2 IPv6 packet length to be 96, got %d", n)
+	}
+}
+
+func TestClientSendsBothIPv4AndIPv6(t *testing.T) {
+	server, _ := net.ListenPacket("udp", "127.0.0.1:0")
+	defer server.Close()
+	port := server.LocalAddr().(*net.UDPAddr).Port
+
+	c := &Client{
+		key: client.key, hmacKey: client.hmacKey,
+		IPs: []net.IPNet{ipNet("127.0.0.1/32"), ipNet("2001:db8::1/64")},
+	}
+	go func() {
+		err := c.send("127.0.0.1", port)
+		if err != nil {
+			t.Errorf("Expected no error %s", err)
+		}
+	}()
+
+	buf := make([]byte, 512)
+	// Expect 2 packets: v2 IPv4 + v2 IPv6 (IPv4 first)
+	for i := 0; i < 2; i++ {
+		n, _, err := server.ReadFrom(buf)
+		if err != nil {
+			t.Fatalf("packet %d: unexpected error: %s", i, err)
+		}
+		if n != 96 {
+			t.Errorf("packet %d: expected length 96, got %d", i, n)
+		}
 	}
 }
 

--- a/client_test.go
+++ b/client_test.go
@@ -122,14 +122,14 @@ func TestClientSendsBothIPv4AndIPv6(t *testing.T) {
 	}()
 
 	buf := make([]byte, 512)
-	// Expect 2 packets: IPv4 (80 bytes) + IPv6 (96 bytes)
+	// Expect 2 packets: both 96 bytes (32/44 bytes pad to 48 -> +16 IV = 64 -> +32 HMAC = 96)
 	for i := 0; i < 2; i++ {
 		n, _, err := server.ReadFrom(buf)
 		if err != nil {
 			t.Fatalf("packet %d: unexpected error: %s", i, err)
 		}
-		if n != 80 && n != 96 {
-			t.Errorf("packet %d: expected length 80 or 96, got %d", i, n)
+		if n != 96 {
+			t.Errorf("packet %d: expected length 96, got %d", i, n)
 		}
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/84codes/sparoid.go
 
-go 1.21
+go 1.25

--- a/message.go
+++ b/message.go
@@ -1,0 +1,48 @@
+package sparoid
+
+import (
+	"crypto/rand"
+	"encoding/binary"
+	"fmt"
+	"net"
+	"time"
+)
+
+// MessageV2 builds a v2 message (34 or 46 bytes) for the given IP and CIDR prefix.
+func MessageV2(ip net.IP, prefixLen uint8) ([]byte, error) {
+	ipv4 := ip.To4()
+	if ipv4 != nil {
+		return messageV2IPv4(ipv4, prefixLen)
+	}
+	ipv6 := ip.To16()
+	if ipv6 == nil {
+		return nil, fmt.Errorf("invalid IP address")
+	}
+	return messageV2IPv6(ipv6, prefixLen)
+}
+
+func messageV2IPv4(ipv4 net.IP, prefixLen uint8) ([]byte, error) {
+	buf := make([]byte, 34)
+	binary.BigEndian.PutUint32(buf[0:4], 2)
+	binary.BigEndian.PutUint64(buf[4:12], uint64(time.Now().UTC().UnixNano()/int64(time.Millisecond)))
+	if _, err := rand.Read(buf[12:28]); err != nil {
+		return nil, err
+	}
+	buf[28] = 4
+	copy(buf[29:33], ipv4)
+	buf[33] = prefixLen
+	return buf, nil
+}
+
+func messageV2IPv6(ipv6 net.IP, prefixLen uint8) ([]byte, error) {
+	buf := make([]byte, 46)
+	binary.BigEndian.PutUint32(buf[0:4], 2)
+	binary.BigEndian.PutUint64(buf[4:12], uint64(time.Now().UTC().UnixNano()/int64(time.Millisecond)))
+	if _, err := rand.Read(buf[12:28]); err != nil {
+		return nil, err
+	}
+	buf[28] = 6
+	copy(buf[29:45], ipv6)
+	buf[45] = prefixLen
+	return buf, nil
+}

--- a/message.go
+++ b/message.go
@@ -8,41 +8,26 @@ import (
 	"time"
 )
 
-// MessageV2 builds a v2 message (34 or 46 bytes) for the given IP and CIDR prefix.
-func MessageV2(ip net.IP, prefixLen uint8) ([]byte, error) {
-	ipv4 := ip.To4()
-	if ipv4 != nil {
-		return messageV2IPv4(ipv4, prefixLen)
+// Message builds a v1 message for the given IP.
+// Format: version(4) + timestamp(8) + nonce(16) + ip(4 or 16)
+// IPv4: 32 bytes, IPv6: 44 bytes. Server distinguishes by length.
+func Message(ip net.IP) ([]byte, error) {
+	if ipv4 := ip.To4(); ipv4 != nil {
+		return message(ipv4, 32)
 	}
-	ipv6 := ip.To16()
-	if ipv6 == nil {
-		return nil, fmt.Errorf("invalid IP address")
+	if ipv6 := ip.To16(); ipv6 != nil {
+		return message(ipv6, 44)
 	}
-	return messageV2IPv6(ipv6, prefixLen)
+	return nil, fmt.Errorf("invalid IP address")
 }
 
-func messageV2IPv4(ipv4 net.IP, prefixLen uint8) ([]byte, error) {
-	buf := make([]byte, 34)
-	binary.BigEndian.PutUint32(buf[0:4], 2)
+func message(ip net.IP, size int) ([]byte, error) {
+	buf := make([]byte, size)
+	binary.BigEndian.PutUint32(buf[0:4], 1)
 	binary.BigEndian.PutUint64(buf[4:12], uint64(time.Now().UTC().UnixNano()/int64(time.Millisecond)))
 	if _, err := rand.Read(buf[12:28]); err != nil {
 		return nil, err
 	}
-	buf[28] = 4
-	copy(buf[29:33], ipv4)
-	buf[33] = prefixLen
-	return buf, nil
-}
-
-func messageV2IPv6(ipv6 net.IP, prefixLen uint8) ([]byte, error) {
-	buf := make([]byte, 46)
-	binary.BigEndian.PutUint32(buf[0:4], 2)
-	binary.BigEndian.PutUint64(buf[4:12], uint64(time.Now().UTC().UnixNano()/int64(time.Millisecond)))
-	if _, err := rand.Read(buf[12:28]); err != nil {
-		return nil, err
-	}
-	buf[28] = 6
-	copy(buf[29:45], ipv6)
-	buf[45] = prefixLen
+	copy(buf[28:], ip)
 	return buf, nil
 }

--- a/message_test.go
+++ b/message_test.go
@@ -1,0 +1,55 @@
+package sparoid
+
+import (
+	"encoding/binary"
+	"net"
+	"testing"
+)
+
+func TestMessageV2IPv4(t *testing.T) {
+	ip := net.ParseIP("10.0.0.1")
+	msg, err := MessageV2(ip, 32)
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	if len(msg) != 34 {
+		t.Fatalf("expected 34 bytes, got %d", len(msg))
+	}
+	version := binary.BigEndian.Uint32(msg[0:4])
+	if version != 2 {
+		t.Errorf("expected version 2, got %d", version)
+	}
+	if msg[28] != 4 {
+		t.Errorf("expected family 4, got %d", msg[28])
+	}
+	if !net.IP(msg[29:33]).Equal(ip.To4()) {
+		t.Errorf("expected IP %s at offset 29, got %s", ip, net.IP(msg[29:33]))
+	}
+	if msg[33] != 32 {
+		t.Errorf("expected range 32, got %d", msg[33])
+	}
+}
+
+func TestMessageV2IPv6(t *testing.T) {
+	ip := net.ParseIP("2001:db8::1")
+	msg, err := MessageV2(ip, 128)
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	if len(msg) != 46 {
+		t.Fatalf("expected 46 bytes, got %d", len(msg))
+	}
+	version := binary.BigEndian.Uint32(msg[0:4])
+	if version != 2 {
+		t.Errorf("expected version 2, got %d", version)
+	}
+	if msg[28] != 6 {
+		t.Errorf("expected family 6, got %d", msg[28])
+	}
+	if !net.IP(msg[29:45]).Equal(ip) {
+		t.Errorf("expected IP %s at offset 29, got %s", ip, net.IP(msg[29:45]))
+	}
+	if msg[45] != 128 {
+		t.Errorf("expected range 128, got %d", msg[45])
+	}
+}

--- a/message_test.go
+++ b/message_test.go
@@ -6,50 +6,38 @@ import (
 	"testing"
 )
 
-func TestMessageV2IPv4(t *testing.T) {
+func TestMessageIPv4(t *testing.T) {
 	ip := net.ParseIP("10.0.0.1")
-	msg, err := MessageV2(ip, 32)
+	msg, err := Message(ip)
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
-	if len(msg) != 34 {
-		t.Fatalf("expected 34 bytes, got %d", len(msg))
+	if len(msg) != 32 {
+		t.Fatalf("expected 32 bytes, got %d", len(msg))
 	}
 	version := binary.BigEndian.Uint32(msg[0:4])
-	if version != 2 {
-		t.Errorf("expected version 2, got %d", version)
+	if version != 1 {
+		t.Errorf("expected version 1, got %d", version)
 	}
-	if msg[28] != 4 {
-		t.Errorf("expected family 4, got %d", msg[28])
-	}
-	if !net.IP(msg[29:33]).Equal(ip.To4()) {
-		t.Errorf("expected IP %s at offset 29, got %s", ip, net.IP(msg[29:33]))
-	}
-	if msg[33] != 32 {
-		t.Errorf("expected range 32, got %d", msg[33])
+	if !net.IP(msg[28:32]).Equal(ip.To4()) {
+		t.Errorf("expected IP %s at offset 28, got %s", ip, net.IP(msg[28:32]))
 	}
 }
 
-func TestMessageV2IPv6(t *testing.T) {
+func TestMessageIPv6(t *testing.T) {
 	ip := net.ParseIP("2001:db8::1")
-	msg, err := MessageV2(ip, 128)
+	msg, err := Message(ip)
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
-	if len(msg) != 46 {
-		t.Fatalf("expected 46 bytes, got %d", len(msg))
+	if len(msg) != 44 {
+		t.Fatalf("expected 44 bytes, got %d", len(msg))
 	}
 	version := binary.BigEndian.Uint32(msg[0:4])
-	if version != 2 {
-		t.Errorf("expected version 2, got %d", version)
+	if version != 1 {
+		t.Errorf("expected version 1, got %d", version)
 	}
-	if msg[28] != 6 {
-		t.Errorf("expected family 6, got %d", msg[28])
-	}
-	if !net.IP(msg[29:45]).Equal(ip) {
-		t.Errorf("expected IP %s at offset 29, got %s", ip, net.IP(msg[29:45]))
-	}
-	if msg[45] != 128 {
-		t.Errorf("expected range 128, got %d", msg[45])
+	if !net.IP(msg[28:44]).Equal(ip) {
+		t.Errorf("expected IP %s at offset 28, got %s", ip, net.IP(msg[28:44]))
 	}
 }


### PR DESCRIPTION
### WHY are these changes introduced?

Please fill me in.

### WHAT is this pull request doing?
- Adds ipv6 support
- Extract message construction into message.go
- update IP resolution to use icanhazip.com with global IPv6 from interfaces as preferred source
- send packets to all resolved host addresses.

### HOW was this pull request tested?

Specs and manually testing towards a compatible sparoid server.
<!---

Friendly reminders

- Write documentation (Internal, API, Website)
- Include reference to Trello (or possibly Slack)
- Include changelog to support if applicable
- The environment (`heroku config`) has been updated if needed (new `ENV` variables)

-->
